### PR TITLE
Simplify HTML import for now

### DIFF
--- a/lib/definitions/index.js
+++ b/lib/definitions/index.js
@@ -5,29 +5,13 @@ import ListItemNode from './list-item-node'
 // a dictionary of node types
 // when this gets too large - refactor to be separate file per definition
 export default {
-  'hr:root': {
-    Class: ContainerNode
-    // this is where we should add specific constraints to the nodes
-    // eg: whitelist valid properties
-    // or properties which are explicit errors
-    // or other configuration variables which define how this node type should be used.
-  },
-  'co:ListItem': {
-    Class: ListItemNode
-  },
-  'doco:Section': {
-    Class: ContainerNode
-  },
-  'doco:Paragraph': {
-    Class: ContainerNode
-  },
-  'doco:Title': {
-    Class: ContainerNode
-  },
-  'po:Block': {
-    Class: ContainerNode
-  },
-  'po:Inline': {
-    Class: ContainerNode
-  }
+  'hr:root': ContainerNode,
+  'hr:head': ContainerNode,
+  'hr:body': ContainerNode,
+  'co:ListItem': ListItemNode,
+  'doco:Section': ContainerNode,
+  'doco:Paragraph': ContainerNode,
+  'doco:Title': ContainerNode,
+  'po:Block': ContainerNode,
+  'po:Inline': ContainerNode
 }

--- a/lib/hyperreadings.js
+++ b/lib/hyperreadings.js
@@ -61,6 +61,11 @@ HyperReadings.prototype.root = async function () {
   return this.node(triples[0])
 }
 
+HyperReadings.prototype.iterate = async function (...args) {
+  const r = await this.root()
+  return r.iterate(...args)
+}
+
 /** Get all nodes by type */
 HyperReadings.prototype.nodesByType = async function (type, opts) {
   // big question - how do we maintain new node names not clashing with old.
@@ -84,8 +89,8 @@ HyperReadings.prototype.node = async function (data, context) {
   if (!type) {
     type = await this._getType(name)
   }
-  const definition = definitions[type]
-  if (definition) return new definition.Class(this, name, type, context)
+  const DefinitionClass = definitions[type]
+  if (DefinitionClass) return new DefinitionClass(this, name, type, context)
   return new StandardNode(this, name, type, context)
 }
 

--- a/lib/hyperreadings.js
+++ b/lib/hyperreadings.js
@@ -90,14 +90,22 @@ HyperReadings.prototype.node = async function (data, context) {
 }
 
 /** Create a new blank node of type */
-HyperReadings.prototype.createNode = async function (type) {
+HyperReadings.prototype.createNode = async function (type, properties) {
+  if (!type) {
+    throw new Error('Cannot create a node without type')
+  }
   // big question - how do we maintain new node names not clashing with old.
   const name = await this._name()
   const newNodeName = name + 'n' + this._nodeCount++
   const triple = spo(newNodeName, 'rdf:type', type)
   await this._put(triple)
   // BUG triple is mutated by put, change this once fixed
-  return this.node(spo(newNodeName, 'rdf:type', type))
+  const node = await this.node(spo(newNodeName, 'rdf:type', type))
+  if (properties) {
+    // TODO: enable arrays to be added too.
+    await Promise.all(Object.keys(properties).map(key => node.set(key, properties[key])))
+  }
+  return node
 }
 
 /** Returns node type */

--- a/lib/importers/html.js
+++ b/lib/importers/html.js
@@ -23,7 +23,8 @@ var describeTitle = createTypeDescriptionStatementWithTextContent('doco:Title')
 var describeSection = createTypeDescriptionStatement('doco:Section')
 // var describeInlineElement = createTypeDescriptionStatement('po:Inline')
 var describeHTML = createTypeDescriptionStatement('hr:root')
-
+var describeBody = createTypeDescriptionStatement('hr:body')
+var describeHead = createTypeDescriptionStatement('hr:head')
 // TODO: bring this back, but as annotations on text sections
 // async function describeLink (hr, node) {
 //   const href = attr(node, 'href')
@@ -63,6 +64,8 @@ function isEmptyNode (node) {
 // TYPES
 var htmlNodeMappings = {
   'html': describeHTML,
+  'head': describeHead,
+  'body': describeBody,
   'section': describeSection,
   'p': describeParagraph,
   'h1': describeTitle,
@@ -132,7 +135,7 @@ export default async function htmlImporter (hr, html) {
     // process individual node
     var mapper = htmlNodeMappings[node.nodeName] || defaultMapping
     // add all children to the queue to be processed next
-    var { hrNode, terminal } = await mapper(hr, node)
+    var { node: hrNode, terminal } = await mapper(hr, node)
     if (context && context.parent && context.parent.insertNode) await context.parent.insertNode(hrNode)
     if (terminal) return
     if (!node.childNodes && node.childNodes.length === 0) return

--- a/lib/importers/html.js
+++ b/lib/importers/html.js
@@ -1,54 +1,58 @@
 import parse5 from 'parse5'
+import { /* attr, */ textContent } from './parse5Helpers'
 import arrayToTree from '../array-to-tree'
 
-function createTypeDescribeStatement (type) {
+function createTypeDescriptionStatement (type) {
   return async (hr, node) => {
     return hr.createNode(type)
   }
 }
 
-function getAttr (node, name) {
-  if (!node || !node.attrs) return undefined
-  const attr = node.attrs.find(attr => attr.name === name)
-  return attr && attr.value
-}
-
-var describeParagraph = createTypeDescribeStatement('doco:Paragraph')
-var describeTitle = createTypeDescribeStatement('doco:Title')
-var describeSection = createTypeDescribeStatement('doco:Section')
-var describeInlineElement = createTypeDescribeStatement('po:Inline')
-var describeHTML = createTypeDescribeStatement('hr:root')
-
-async function describeLink (hr, node) {
-  const href = getAttr(node, 'href')
-  if (!href) return
-  const identifer = await hr.createNode('datacite:AlternateResourceIdentifier')
-  await identifer.set('cito:usesIdentifierScheme', 'datacite:url')
-  await identifer.set('rdf:value', href.value)
-  const linkNode = await hr.createNode('po:Inline')
-  await linkNode.set('cito:hasIdentifier', identifer)
-  return linkNode
-}
-
-async function describeText (hr, node) {
-  const text = await hr.createNode('doco:TextChunk')
-  await text.set('rdf:value', node.value)
-  return text
-}
-
-async function describeSpan (hr, node) {
-  switch (getAttr(node, 'data-type')) {
-    case 'comment': {
-      const text = getAttr(node, 'data-comment')
-      const comment = await hr.createNode('fabio:Comment')
-      await comment.set('c4o:hasContent', text)
-      return comment
-    }
-    default: {
-      return hr.createNode('po:Inline')
-    }
+function createTypeDescriptionStatementWithTextContent (type) {
+  return async (hr, node) => {
+    return hr.createNode(type, {
+      'c4o:hasContent': textContent(node)
+    })
   }
 }
+
+var describeParagraph = createTypeDescriptionStatementWithTextContent('doco:Paragraph')
+var describeTitle = createTypeDescriptionStatementWithTextContent('doco:Title')
+var describeSection = createTypeDescriptionStatement('doco:Section')
+// var describeInlineElement = createTypeDescriptionStatement('po:Inline')
+var describeHTML = createTypeDescriptionStatement('hr:root')
+
+// TODO: bring this back, but as annotations on text sections
+// async function describeLink (hr, node) {
+//   const href = attr(node, 'href')
+//   if (!href) return
+//   const identifer = await hr.createNode('datacite:AlternateResourceIdentifier')
+//   await identifer.set('cito:usesIdentifierScheme', 'datacite:url')
+//   await identifer.set('rdf:value', href.value)
+//   const linkNode = await hr.createNode('po:Inline')
+//   await linkNode.set('cito:hasIdentifier', identifer)
+//   return linkNode
+// }
+
+// async function describeText (hr, node) {
+//   const text = await hr.createNode('doco:TextChunk')
+//   await text.set('rdf:value', node.value)
+//   return text
+// }
+
+// async function describeSpan (hr, node) {
+//   switch (attr(node, 'data-type')) {
+//     case 'comment': {
+//       const text = attr(node, 'data-comment')
+//       const comment = await hr.createNode('fabio:Comment')
+//       await comment.set('c4o:hasContent', text)
+//       return comment
+//     }
+//     default: {
+//       return hr.createNode('po:Inline')
+//     }
+//   }
+// }
 
 function isEmptyNode (node) {
   return !node.childNodes && node.value && /^\s*$/.test(node.value)
@@ -64,14 +68,15 @@ var htmlNodeMappings = {
   'h3': describeTitle,
   'h4': describeTitle,
   'h5': describeTitle,
-  'h6': describeTitle,
-  '#text': describeText,
-  'em': describeInlineElement,
-  'i': describeInlineElement,
-  'strong': describeInlineElement,
-  'b': describeInlineElement,
-  'a': describeLink,
-  'span': describeSpan
+  'h6': describeTitle
+  // '#text': describeText,
+  // TODO: implement inline elements as annotations on content
+  // 'em': describeInlineElement,
+  // 'i': describeInlineElement,
+  // 'strong': describeInlineElement,
+  // 'b': describeInlineElement,
+  // 'a': describeLink,
+  // 'span': describeSpan
 }
 var defaultMapping = function (hr, node) {
   // make this inherited from parent / inline or block

--- a/lib/importers/html.js
+++ b/lib/importers/html.js
@@ -4,15 +4,17 @@ import arrayToTree from '../array-to-tree'
 
 function createTypeDescriptionStatement (type) {
   return async (hr, node) => {
-    return hr.createNode(type)
+    const n = await hr.createNode(type)
+    return { node: n }
   }
 }
 
 function createTypeDescriptionStatementWithTextContent (type) {
   return async (hr, node) => {
-    return hr.createNode(type, {
+    const n = await hr.createNode(type, {
       'c4o:hasContent': textContent(node)
     })
+    return { node: n, terminal: true }
   }
 }
 
@@ -130,15 +132,14 @@ export default async function htmlImporter (hr, html) {
     // process individual node
     var mapper = htmlNodeMappings[node.nodeName] || defaultMapping
     // add all children to the queue to be processed next
-    var hrNode = await mapper(hr, node)
+    var { hrNode, terminal } = await mapper(hr, node)
     if (context && context.parent && context.parent.insertNode) await context.parent.insertNode(hrNode)
-
-    if (node.childNodes && node.childNodes.length > 0) {
-      if (!node.inferred) node.childNodes = addInferredSections(node.childNodes)
-      const next = nextNodes(hrNode, node.childNodes)
-      // push next to stack
-      // console.log(next)
-      Array.prototype.push.apply(stack, next)
-    }
+    if (terminal) return
+    if (!node.childNodes && node.childNodes.length === 0) return
+    if (!node.inferred) node.childNodes = addInferredSections(node.childNodes)
+    const next = nextNodes(hrNode, node.childNodes)
+    // push next to stack
+    // console.log(next)
+    Array.prototype.push.apply(stack, next)
   }
 }

--- a/lib/importers/html.js
+++ b/lib/importers/html.js
@@ -7,6 +7,12 @@ function createTypeDescribeStatement (type) {
   }
 }
 
+function getAttr (node, name) {
+  if (!node || !node.attrs) return undefined
+  const attr = node.attrs.find(attr => attr.name === name)
+  return attr && attr.value
+}
+
 var describeParagraph = createTypeDescribeStatement('doco:Paragraph')
 var describeTitle = createTypeDescribeStatement('doco:Title')
 var describeSection = createTypeDescribeStatement('doco:Section')
@@ -14,7 +20,7 @@ var describeInlineElement = createTypeDescribeStatement('po:Inline')
 var describeHTML = createTypeDescribeStatement('hr:root')
 
 async function describeLink (hr, node) {
-  const href = node.attrs.find(attr => attr.name === 'href')
+  const href = getAttr(node, 'href')
   if (!href) return
   const identifer = await hr.createNode('datacite:AlternateResourceIdentifier')
   await identifer.set('cito:usesIdentifierScheme', 'datacite:url')
@@ -28,6 +34,20 @@ async function describeText (hr, node) {
   const text = await hr.createNode('doco:TextChunk')
   await text.set('rdf:value', node.value)
   return text
+}
+
+async function describeSpan (hr, node) {
+  switch (getAttr(node, 'data-type')) {
+    case 'comment': {
+      const text = getAttr(node, 'data-comment')
+      const comment = await hr.createNode('fabio:Comment')
+      await comment.set('c4o:hasContent', text)
+      return comment
+    }
+    default: {
+      return hr.createNode('po:Inline')
+    }
+  }
 }
 
 function isEmptyNode (node) {
@@ -50,7 +70,8 @@ var htmlNodeMappings = {
   'i': describeInlineElement,
   'strong': describeInlineElement,
   'b': describeInlineElement,
-  'a': describeLink
+  'a': describeLink,
+  'span': describeSpan
 }
 var defaultMapping = function (hr, node) {
   // make this inherited from parent / inline or block

--- a/lib/importers/parse5Helpers.js
+++ b/lib/importers/parse5Helpers.js
@@ -1,0 +1,32 @@
+function * iterator (node) {
+  if (!node.childNodes || node.childNodes.length === 0) return
+  for (let child of node.childNodes) {
+    yield child
+    yield * iterator(child)
+  }
+}
+
+function accumulator (node, reducer, ctx) {
+  const itr = iterator(node)
+  let c = itr.next().value
+  while (c) {
+    ctx = reducer(ctx, c)
+    c = itr.next().value
+  }
+  return ctx
+}
+
+export function textContent (node) {
+  return accumulator(node, (prev, child) => {
+    if (child.nodeName === '#text') return prev + child.value
+    // maybe should not do this.. but lets roll with it for now
+    else if (child.nodeName === 'br') return prev + '\n'
+    return prev
+  }, '')
+}
+
+export function attr (node, name) {
+  if (!node || !node.attrs) return undefined
+  const attr = node.attrs.find(attr => attr.name === name)
+  return attr && attr.value
+}

--- a/test/hyperreadings.test.js
+++ b/test/hyperreadings.test.js
@@ -62,11 +62,43 @@ describe('hyperreadings', () => {
       })
     })
 
-    // describe('hr.createNode(type)', () => {
-    //   it('adds a new blank node to the graph', async () => {
-    //     const n = await hr.createNode('http://example.com/namespace/')
-    //     // find disconnected nodes and expect node.name to be found.
-    //   })
-    // })
+    describe('hr.nodesByType(type)', () => {
+      it('adds a new blank node to the graph', async () => {
+        const type = 'http://example.com/namespace/'
+        await hr.createNode(type)
+        await hr.createNode(type)
+        await hr.createNode('not-this-one')
+        const nodes = await hr.nodesByType(type)
+        expect(nodes).to.have.length(2)
+        nodes.forEach(node => expect(node.type).to.eql(type))
+      })
+    })
+
+    describe('hr.createNode(type)', () => {
+      it('adds a new blank node to the graph of type', async () => {
+        const type = 'http://example.com/namespace/'
+        const n = await hr.createNode(type)
+        const nodes = await hr.nodesByType(type)
+        expect(nodes).to.have.length(1)
+        expect(nodes[0].name).to.eql(n.name)
+      })
+      it('returns rejected promise if no type is provided', () => {
+        return hr.createNode()
+          .then(() => expect.fail())
+          .catch(err => {
+            expect(err).to.be.an('error')
+            expect(err.message).to.be.string('Cannot create a node without type')
+          })
+      })
+      it('allows you to set properties when creating', async () => {
+        const type = 'http://example.com/namespace/'
+        const data = {'rdf:value': 23, 'c4o:hasContent': 'very import contents'}
+        const n = await hr.createNode(type, data)
+        const nodes = await hr.nodesByType(type)
+        expect(nodes).to.have.length(1)
+        expect(await n.get('rdf:value')).to.eql(data['rdf:value'])
+        expect(await n.get('c4o:hasContent')).to.eql(data['c4o:hasContent'])
+      })
+    })
   })
 })

--- a/test/importers/markdown.test.js
+++ b/test/importers/markdown.test.js
@@ -1,23 +1,49 @@
 /* eslint-env mocha */
 
-// var expect = require('chai').expect
-// var fs = require('fs')
+import { expect } from 'chai'
 import hyperreadings from '../../lib/hyperreadings'
 import markdownImporter from '../../lib/importers/markdown'
 
 describe('markdownImporter', () => {
-  it('imports markdown file into a hyper readinglist', async () => {
-    // const file = fs.readFileSync('./reading-lists/hyper-graph-db-research.md')
-    // '# Hello *world*!!!'
-    const test = '# yes\n\nno\nmaybe'
-    const hr = hyperreadings()
-    await markdownImporter(hr, test) // file.toString())
-    // const base = await hr.root()
-    // await base.iterate(print)
-    // async function print (node) {
-    //   console.log(node.name, node.type)
-    //   console.log(await node.get('rdf:value'))
-    //   if (node.iterate) await node.iterate(print)
-    // }
-  }).timeout(6000)
+  context('with very simple markdown', () => {
+    let hr
+    before(async () => {
+      const test = '# yes\n\nno\nmaybe'
+      hr = hyperreadings()
+      return markdownImporter(hr, test)
+    })
+    it('contains head and body nodes', async () => {
+      const expected = ['hr:head', 'hr:body']
+      await hr.iterate((node) => {
+        expect(node.type).to.eql(expected.shift())
+      })
+    })
+    it('has an empty head', async () => {
+      const heads = await hr.nodesByType('hr:head', {limit: 1})
+      const head = heads[0]
+      await head.iterate((node) => {
+        expect.fail()
+      })
+    })
+    it('has body with single section node', async () => {
+      const bodys = await hr.nodesByType('hr:body', {limit: 1})
+      const body = bodys[0]
+      const expected = ['doco:Section']
+      await body.iterate((node) => {
+        expect(node.type).to.eql(expected.shift())
+      })
+    })
+    it('has section to have Title and Paragraph', async () => {
+      const bodys = await hr.nodesByType('doco:Section', {limit: 1})
+      const body = bodys[0]
+      const expected = [
+        { type: 'doco:Title', 'c4o:hasContent': 'yes' },
+        { type: 'doco:Paragraph', 'c4o:hasContent': 'no\nmaybe' }]
+      await body.iterate(async (node) => {
+        const x = expected.shift()
+        expect(node.type).to.eql(x.type)
+        expect(await node.get('c4o:hasContent')).to.eql(x['c4o:hasContent'])
+      })
+    })
+  }).timeout(5000)
 })

--- a/test/importers/parse5Helpers.test.js
+++ b/test/importers/parse5Helpers.test.js
@@ -1,0 +1,67 @@
+/* eslint-env mocha */
+import parse5 from 'parse5'
+import { expect } from 'chai'
+import { attr, textContent } from '../../lib/importers/parse5Helpers'
+
+describe('attr', () => {
+  let node
+  before(() => {
+    node = parse5.parseFragment('<div id="test" data-node="something" class="class names">something</div>').childNodes[0]
+  })
+  it('returns a attribute value from node (id)', () => {
+    console.log(node)
+    const output = attr(node, 'id')
+    expect(output).to.eql('test')
+  })
+  it('returns a attribute value from node (data-attr)', () => {
+    const output = attr(node, 'data-node')
+    expect(output).to.eql('something')
+  })
+  it('returns a attribute value from node (class)', () => {
+    const output = attr(node, 'class')
+    expect(output).to.eql('class names')
+  })
+  it('returns a attribute value from node (class)', () => {
+    const output = attr(node, 'data-not-set')
+    expect(output).to.eql(undefined)
+  })
+  it('returns undefined if node is falsy', () => {
+    expect(attr()).to.eql(undefined)
+  })
+})
+
+describe('textContent', () => {
+  it('returns text content from node (simple)', () => {
+    const fragment = '<div>so what</div>'
+    const node = parse5.parseFragment(fragment).childNodes[0]
+    expect(textContent(node)).to.eql('so what')
+  })
+  it('returns text content from node (nested)', () => {
+    const fragment = '<div>deeply <h1>nested <span><strong>node</strong> <em>also</em></span> works</h1></div>'
+    const node = parse5.parseFragment(fragment).childNodes[0]
+    expect(textContent(node)).to.eql('deeply nested node also works')
+  })
+  it('returns text content from node (preserves white spaces over lines)', () => {
+    const fragment = `<div>
+    over
+    lines
+    </div>`
+    const node = parse5.parseFragment(fragment).childNodes[0]
+    expect(textContent(node)).to.eql('\n    over\n    lines\n    ')
+  })
+  it('returns text content from node (preserves white spaces)', () => {
+    const fragment = `<div>    over     lines      </div>`
+    const node = parse5.parseFragment(fragment).childNodes[0]
+    expect(textContent(node)).to.eql('    over     lines      ')
+  })
+  it('returns text content from node (html breaks)', () => {
+    const fragment = `<div>over</br>lines</div>`
+    const node = parse5.parseFragment(fragment).childNodes[0]
+    expect(textContent(node)).to.eql('over\nlines')
+  })
+  it('returns text content from node (html breaks unclosed)', () => {
+    const fragment = `<div>over<br>lines</div>`
+    const node = parse5.parseFragment(fragment).childNodes[0]
+    expect(textContent(node)).to.eql('over\nlines')
+  })
+})

--- a/test/importers/parse5Helpers.test.js
+++ b/test/importers/parse5Helpers.test.js
@@ -50,17 +50,17 @@ describe('textContent', () => {
     expect(textContent(node)).to.eql('\n    over\n    lines\n    ')
   })
   it('returns text content from node (preserves white spaces)', () => {
-    const fragment = `<div>    over     lines      </div>`
+    const fragment = '<div>    over     lines      </div>'
     const node = parse5.parseFragment(fragment).childNodes[0]
     expect(textContent(node)).to.eql('    over     lines      ')
   })
   it('returns text content from node (html breaks)', () => {
-    const fragment = `<div>over</br>lines</div>`
+    const fragment = '<div>over</br>lines</div>'
     const node = parse5.parseFragment(fragment).childNodes[0]
     expect(textContent(node)).to.eql('over\nlines')
   })
   it('returns text content from node (html breaks unclosed)', () => {
-    const fragment = `<div>over<br>lines</div>`
+    const fragment = '<div>over<br>lines</div>'
     const node = parse5.parseFragment(fragment).childNodes[0]
     expect(textContent(node)).to.eql('over\nlines')
   })


### PR DESCRIPTION
This is to make it easier to integrate into hyper-reader - by removing complexity of annotations. For example a, em, strong, etc.

These will be stage two. As annotations on nodes that have c4o:hasContent properties.

The plan is to have these as linked nodes with index predicates e.g.: to, and from. Hopefully this will reduce the space needed to store annotations, and enable quickly grabbing text content without the need to iterate over lots of nested elements.